### PR TITLE
Extended built-in Spec class

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,12 @@ const { issueCommand, issue } = require("@actions/core/lib/command");
 const mocha = require("mocha");
 const { extractModuleLineAndColumn } = require("./parse-stack-trace");
 
-const { Base } = mocha.reporters;
+const { Spec } = mocha.reporters;
+const { inherits } = mocha.utils;
 const { EVENT_TEST_FAIL, EVENT_RUN_END } = mocha.Runner.constants;
 
-function GithubActionsReporter(runner) {
-  Base.call(this, runner);
+function GithubActionsReporter(runner, options) {
+  Spec.call(this, runner, options);
 
   const failures = [];
 
@@ -37,5 +38,10 @@ function GithubActionsReporter(runner) {
     issue("endgroup");
   });
 }
+
+/**
+ * Inherit from `Spec.prototype`.
+ */
+inherits(GithubActionsReporter, Spec);
 
 module.exports = GithubActionsReporter;


### PR DESCRIPTION
fixes #1

- this commit extends the built-in Spec reporter in order to keep the
  test output